### PR TITLE
Features/asset retargeting clean output

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MixedRealityToolkit/Utilities/AssetScriptReferenceRetargeter.cs
@@ -124,6 +124,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                     Debug.LogError($"Can't find a compiled version of the script: {pair.Key}; guid: {pair.Value.Guid}");
                 }
             }
+
             ProcessYAMLAssets(allFilesUnderAssets, Application.dataPath.Replace("Assets", "NuGet/Output"), remapDictionary);
         }
 


### PR DESCRIPTION
Overview
---
After all output files have been created, walk the directory tree and prune any folders that are empty or that only contain unassociated .meta files.